### PR TITLE
<systemd/var_sub: Change environment variable definition>

### DIFF
--- a/systemd/moolticute-ssh-agent.service
+++ b/systemd/moolticute-ssh-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Moolticute SSH key agent
+Requires=moolticuted.service
 
 [Service]
 Type=simple

--- a/systemd/moolticute-ssh-agent.service
+++ b/systemd/moolticute-ssh-agent.service
@@ -3,8 +3,8 @@ Description=Moolticute SSH key agent
 
 [Service]
 Type=simple
-Environment=SSH_AUTH_SOCK=%t/moolticute-ssh-agent.socket
-ExecStart=/usr/bin/moolticute_ssh-agent --address=$SSH_AUTH_SOCK --no-fork
+Environment="SSH_AUTH_SOCK=%t/moolticute-ssh-agent.socket"
+ExecStart=/usr/bin/moolticute_ssh-agent --address=${SSH_AUTH_SOCK} --no-fork
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
I run into difficulties with the old syntax in which environment
variable are not substitued on the systemd command line.