### PR TITLE
More info in --help and link to project docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-APPNAME = moolticute_ssh-agent
+APPNAME = mc-agent
 
 TAGS = ""
 BUILD_FLAGS = "-v"

--- a/constants_nix.go
+++ b/constants_nix.go
@@ -1,0 +1,18 @@
+// +build linux darwin
+
+package main
+
+const (
+  LongHelpText = `SSH agent that uses moolticute to store/load your keys
+
+An easy way to setup is to enable the "Autostart SSH Agent" setting in the Moolticute app, and set
+the "Moolticute SSH Arguments" to something like:
+
+  --address /tmp/mc-agent.socket
+
+After which mc-agent will be automatically used if the following is added to .bashrc (or similar):
+
+  export SSH_AUTH_SOCK=/tmp/mc-agent.socket
+
+For more information: https://github.com/raoulh/mc-agent/blob/master/docs/mc-agent.md`
+)

--- a/constants_win.go
+++ b/constants_win.go
@@ -1,0 +1,12 @@
+// +build windows
+
+package main
+
+const (
+  LongHelpText = `SSH agent that uses moolticute to store/load your keys and emulates the PuTTY
+agent.
+
+An easy way to setup is to enable the "Autostart SSH Agent" setting in the Moolticute app.
+
+For more information: https://github.com/raoulh/mc-agent/blob/master/docs/mc-agent.md`
+)

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func exit(err error, exit int) {
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	app := cli.App("mc-agent", "SSH agent that use moolticute to store/load your keys")
+	app := cli.App("mc-agent", LongHelpText)
 
 	app.Spec = "[-d][-m][--debug][-p]"
 


### PR DESCRIPTION
In addition to the extra help info and link, I renamed `APPNAME = mc-agent` because that's what the Makefile expects when doing the `cp '$(GOPATH)/bin/$(APPNAME)' .`.